### PR TITLE
Better error message when std::fs::canonicalize() fails

### DIFF
--- a/src/package.rs
+++ b/src/package.rs
@@ -204,7 +204,13 @@ impl Package {
                 // they may be unpacked.
                 add_directory_and_parents(archive, path.to.parent().unwrap())?;
             }
-            let from_root = std::fs::canonicalize(&path.from)?;
+            let from_root = std::fs::canonicalize(&path.from).map_err(|e| {
+                anyhow!(
+                    "failed to canonicalize \"{}\": {}",
+                    path.from.to_string_lossy(),
+                    e
+                )
+            })?;
             let entries = walkdir::WalkDir::new(&from_root)
                 // Pick up symlinked files.
                 .follow_links(true)


### PR DESCRIPTION
I didn't follow instructions well:

```console
ahl@helios:~/omicron$ ./target/debug/omicron-package package
    Finished release [optimized] target(s) in 0.40s
Error: No such file or directory (os error 2)
```

Ok, what's the problem?

```console
ahl@helios:~/omicron$ truss ./target/debug/omicron-package package
...
/1:     resolvepath("clickhouse", 0xFFFFFC7FFFDF2E70, 1024) Err#2 ENOENT
...
```

Right.. I forgot to install clickhouse in this new system.

Where's this coming from?

```console
ahl@helios:~/omicron$ pfexec dtrace -c './target/debug/omicron-package package' -n syscall::resolvepath:return'/pid == $target/{ ustack() }' | c++filt 
dtrace: description 'syscall::resolvepath:return' matched 1 probe
    Finished release [optimized] target(s) in 1.20s
Error: No such file or directory (os error 2)
dtrace: pid 2146 has exited
CPU     ID                    FUNCTION:NAME
  2    397               resolvepath:return 
              libc.so.1`resolvepath+0xa
              libc.so.1`realpath+0x37
              omicron-package`std::sys::unix::fs::canonicalize::hf52f44c41aea67cd+0x110
              omicron-package`std::fs::canonicalize::h4a43833db3b6de65+0x36
              omicron-package`omicron_zone_package::package::Package::add_paths::{{closure}}::h2e8065e712fff325+0x267
              omicron-package`<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h87262a5052ac50a6+0x50
              omicron-package`omicron_zone_package::package::Package::create_zone_package::{{closure}}::h17774e66b8aef559+0xae9
              omicron-package`<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::hcdae5862d475afd9+0x5f
              omicron-package`omicron_zone_package::package::Package::create_internal::{{closure}}::h4ef663e1102a9e79+0x1ba
              omicron-package`<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::hfdc8a9ef51c8e78a+0x5f
              omicron-package`omicron_zone_package::package::Package::create_with_progress::{{closure}}::h25d91ed262b58477+0x112
              omicron-package`<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::he97c5c5d69715360+0x5f
              omicron-package`omicron_package::do_package::{{closure}}::{{closure}}::{{closure}}::hfdd303f5a411ac71+0x1b5
              omicron-package`<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h6cf03f0e4ab0b4ac+0x50
              omicron-package`<futures_util::stream::futures_unordered::FuturesUnordered<Fut> as futures_core::stream::Stream>::poll_next::hd003c00a15fcd787+0x496
              omicron-package`futures_util::stream::stream::StreamExt::poll_next_unpin::h94e7b09d31fba3fa+0x35
              omicron-package`<futures_util::stream::try_stream::try_for_each_concurrent::TryForEachConcurrent<St,Fut,F> as core::future::future::Future>::poll::hc79762ce7f5be100+0xbe
              omicron-package`<tokio::future::maybe_done::MaybeDone<Fut> as core::future::future::Future>::poll::he0f7c6a57b540c2d+0x101
              omicron-package`omicron_package::do_package::{{closure}}::{{closure}}::h6e6e39c81a2de9e9+0x25c
              omicron-package`<tokio::future::poll_fn::PollFn<F> as core::future::future::Future>::poll::h7987f2bd72797fcd+0x36
```

With this fix applied
```console
ahl@helios:~/omicron$ ./target/debug/omicron-package package
    Finished release [optimized] target(s) in 1.31s
Error: failed to canonicalize "clickhouse": No such file or directory (os error 2)
```