### PR TITLE
Add support for parsing in-memory package configurations

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -27,9 +27,13 @@ pub enum ParseError {
     Io(#[from] std::io::Error),
 }
 
+/// Parses a manifest into a package [`Config`].
+pub fn parse_manifest(manifest: &str) -> Result<Config, ParseError> {
+    let cfg = toml::from_str::<Config>(manifest)?;
+    Ok(cfg)
+}
 /// Parses a path in the filesystem into a package [`Config`].
 pub fn parse<P: AsRef<Path>>(path: P) -> Result<Config, ParseError> {
     let contents = std::fs::read_to_string(path.as_ref())?;
-    let cfg = toml::from_str::<Config>(&contents)?;
-    Ok(cfg)
+    parse_manifest(&contents)
 }


### PR DESCRIPTION
Add support for / as a target directory
Minor cargo clippy cleanup