### PR TITLE
Add 'only_for_targets' field

### DIFF
--- a/src/package.rs
+++ b/src/package.rs
@@ -206,17 +206,17 @@ pub struct Package {
 }
 
 impl Package {
-    pub fn get_output_path(&self, output_directory: &Path) -> PathBuf {
+    pub fn get_output_path(&self, name: &str, output_directory: &Path) -> PathBuf {
         if self.zone {
-            output_directory.join(format!("{}.tar.gz", self.service_name))
+            output_directory.join(format!("{}.tar.gz", name))
         } else {
-            output_directory.join(format!("{}.tar", self.service_name))
+            output_directory.join(format!("{}.tar", name))
         }
     }
 
     /// Constructs the package file in the output directory.
-    pub async fn create(&self, output_directory: &Path) -> Result<File> {
-        self.create_internal(&NoProgress, output_directory).await
+    pub async fn create(&self, name: &str, output_directory: &Path) -> Result<File> {
+        self.create_internal(&NoProgress, name, output_directory).await
     }
 
     /// Returns the "total number of things to be done" when constructing a
@@ -254,20 +254,22 @@ impl Package {
     pub async fn create_with_progress(
         &self,
         progress: &impl Progress,
+        name: &str,
         output_directory: &Path,
     ) -> Result<File> {
-        self.create_internal(progress, output_directory).await
+        self.create_internal(progress, name, output_directory).await
     }
 
     async fn create_internal(
         &self,
         progress: &impl Progress,
+        name: &str,
         output_directory: &Path,
     ) -> Result<File> {
         if self.zone {
-            self.create_zone_package(progress, output_directory).await
+            self.create_zone_package(progress, name, output_directory).await
         } else {
-            self.create_tarball_package(progress, output_directory)
+            self.create_tarball_package(progress, name, output_directory)
                 .await
         }
     }
@@ -366,11 +368,12 @@ impl Package {
     async fn create_zone_package(
         &self,
         progress: &impl Progress,
+        name: &str,
         output_directory: &Path,
     ) -> Result<File> {
         // Create a tarball which will become an Omicron-brand image
         // archive.
-        let tarfile = self.get_output_path(output_directory);
+        let tarfile = self.get_output_path(name, output_directory);
         let file = open_tarfile(&tarfile)?;
 
         // TODO: Consider using async compression, async tar.
@@ -424,11 +427,12 @@ impl Package {
     async fn create_tarball_package(
         &self,
         progress: &impl Progress,
+        name: &str,
         output_directory: &Path,
     ) -> Result<File> {
         // Create a tarball containing the necessary executable and auxiliary
         // files.
-        let tarfile = self.get_output_path(output_directory);
+        let tarfile = self.get_output_path(name, output_directory);
         let file = open_tarfile(&tarfile)?;
         // TODO: We could add compression here, if we'd like?
         let mut archive = Builder::new(file);

--- a/src/package.rs
+++ b/src/package.rs
@@ -216,7 +216,8 @@ impl Package {
 
     /// Constructs the package file in the output directory.
     pub async fn create(&self, name: &str, output_directory: &Path) -> Result<File> {
-        self.create_internal(&NoProgress, name, output_directory).await
+        self.create_internal(&NoProgress, name, output_directory)
+            .await
     }
 
     /// Returns the "total number of things to be done" when constructing a
@@ -267,7 +268,8 @@ impl Package {
         output_directory: &Path,
     ) -> Result<File> {
         if self.zone {
-            self.create_zone_package(progress, name, output_directory).await
+            self.create_zone_package(progress, name, output_directory)
+                .await
         } else {
             self.create_tarball_package(progress, name, output_directory)
                 .await

--- a/src/package.rs
+++ b/src/package.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, FixedOffset, Utc};
 use reqwest::header::{CONTENT_LENGTH, LAST_MODIFIED};
 use serde_derive::Deserialize;
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
@@ -193,6 +194,11 @@ pub struct Package {
 
     /// Identifies if the package should be packaged into a zone image.
     pub zone: bool,
+
+    /// Identifies the targets for which the package should be included.
+    ///
+    /// If ommitted, the package is assumed to be included for all targets.
+    pub only_for_targets: Option<BTreeMap<String, String>>,
 
     /// A human-readable string with suggestions for setup if packaging fails.
     #[serde(default)]

--- a/tests/service-d/cfg.toml
+++ b/tests/service-d/cfg.toml
@@ -1,0 +1,5 @@
+[package.my-package]
+service_name = "my-service"
+rust.binary_names = ["test-service"]
+rust.release = false
+zone = false


### PR DESCRIPTION
Allows package manifests to specify that some packages should only be enabled in particular contexts, such as on a specific variant of a machine.

This is the manifest portion of https://github.com/oxidecomputer/omicron/issues/1754