### PR TITLE
Add support for parsing in-memory package configurations

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ impl Config {
     pub fn packages_to_build(&self, target: &Target) -> BTreeMap<&String, &Package> {
         self.packages
             .iter()
-            .filter(|(_, pkg)| target.includes_package(&pkg))
+            .filter(|(_, pkg)| target.includes_package(pkg))
             .map(|(name, pkg)| (name, pkg))
             .collect()
     }
@@ -51,9 +51,13 @@ pub enum ParseError {
     Io(#[from] std::io::Error),
 }
 
+/// Parses a manifest into a package [`Config`].
+pub fn parse_manifest(manifest: &str) -> Result<Config, ParseError> {
+    let cfg = toml::from_str::<Config>(manifest)?;
+    Ok(cfg)
+}
 /// Parses a path in the filesystem into a package [`Config`].
 pub fn parse<P: AsRef<Path>>(path: P) -> Result<Config, ParseError> {
     let contents = std::fs::read_to_string(path.as_ref())?;
-    let cfg = toml::from_str::<Config>(&contents)?;
-    Ok(cfg)
+    parse_manifest(&contents)
 }

--- a/src/package.rs
+++ b/src/package.rs
@@ -123,7 +123,7 @@ fn add_directory_and_parents<W: std::io::Write>(
     }
 
     for parent in parents {
-        let dst = archive_path(&parent)?;
+        let dst = archive_path(parent)?;
         archive.append_dir(&dst, ".")?;
     }
 
@@ -478,7 +478,7 @@ impl Package {
         match &self.source {
             PackageSource::Local { paths, .. } => {
                 // Add mapped paths.
-                self.add_paths(progress, &mut archive, &paths).await?;
+                self.add_paths(progress, &mut archive, paths).await?;
 
                 // Attempt to add the rust binary, if one was built.
                 self.add_rust(progress, &mut archive).await?;
@@ -565,14 +565,14 @@ impl Package {
                 self.add_rust(progress, &mut archive).await?;
 
                 // Add (and possibly download) blobs
-                self.add_blobs(progress, &mut archive, output_directory, &Path::new(BLOB))
+                self.add_blobs(progress, &mut archive, output_directory, Path::new(BLOB))
                     .await?;
 
                 Ok(archive
                     .into_inner()
                     .map_err(|err| anyhow!("Failed to finalize archive: {}", err))?)
             }
-            _ => return Err(anyhow!("Cannot create non-local tarball")),
+            _ => Err(anyhow!("Cannot create non-local tarball")),
         }
     }
 }
@@ -602,7 +602,7 @@ impl RustPackage {
         for name in &self.binary_names {
             archive
                 .append_path_with_name_async(
-                    Self::local_binary_path(&name, self.release),
+                    Self::local_binary_path(name, self.release),
                     dst_directory.join(&name),
                 )
                 .await

--- a/src/target.rs
+++ b/src/target.rs
@@ -35,7 +35,7 @@ impl Target {
                 return false;
             };
         }
-        return true;
+        true
     }
 }
 


### PR DESCRIPTION
Clean up some unrelated clippy warnings.
The only functional change is the addition of `parse_manifest()`