### PR TITLE
Add progress support for sub tasks, e.g. downloading blobs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omicron-zone-package"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Sean Klein <sean@oxidecomputer.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ async-trait = "0.1.64"
 chrono = "0.4.23"
 filetime = "0.2.20"
 flate2 = "1.0.25"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+futures-util = "0.3"
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 tar = "0.4"

--- a/src/package.rs
+++ b/src/package.rs
@@ -346,7 +346,7 @@ impl Package {
         archive: &mut Builder<W>,
         paths: &Vec<MappedPath>,
     ) -> Result<()> {
-        progress.set_message("adding paths");
+        progress.set_message("adding paths".into());
 
         for path in paths {
             match self.output {
@@ -451,7 +451,7 @@ impl Package {
         download_directory: &Path,
         destination_path: &Path,
     ) -> Result<()> {
-        progress.set_message("adding blobs");
+        progress.set_message("adding blobs".into());
         if let Some(blobs) = self.source.blobs() {
             let blobs_path = download_directory.join(&self.service_name);
             std::fs::create_dir_all(&blobs_path)?;
@@ -602,7 +602,7 @@ impl RustPackage {
         dst_directory: &Path,
     ) -> Result<()> {
         for name in &self.binary_names {
-            progress.set_message(format!("adding rust binary: {name}"));
+            progress.set_message(format!("adding rust binary: {name}").into());
             archive
                 .append_path_with_name_async(
                     Self::local_binary_path(name, self.release),

--- a/src/package.rs
+++ b/src/package.rs
@@ -451,15 +451,15 @@ impl Package {
         download_directory: &Path,
         destination_path: &Path,
     ) -> Result<()> {
-        progress.set_message("adding blobs".into());
         if let Some(blobs) = self.source.blobs() {
             let blobs_path = download_directory.join(&self.service_name);
             std::fs::create_dir_all(&blobs_path)?;
             for blob in blobs {
                 let blob_path = blobs_path.join(blob);
-                crate::blob::download(&blob.to_string_lossy(), &blob_path).await?;
+                crate::blob::download(progress, &blob.to_string_lossy(), &blob_path).await?;
                 progress.increment(1);
             }
+            progress.set_message("adding blobs".into());
             archive
                 .append_dir_all_async(&destination_path, &blobs_path)
                 .await?;

--- a/src/package.rs
+++ b/src/package.rs
@@ -261,9 +261,13 @@ async fn new_zone_archive_builder(
 
 impl Package {
     pub fn get_output_path(&self, name: &str, output_directory: &Path) -> PathBuf {
+        output_directory.join(self.get_output_file(name))
+    }
+
+    pub fn get_output_file(&self, name: &str) -> String {
         match self.output {
-            PackageOutput::Zone { .. } => output_directory.join(format!("{}.tar.gz", name)),
-            PackageOutput::Tarball => output_directory.join(format!("{}.tar", name)),
+            PackageOutput::Zone { .. } => format!("{}.tar.gz", name),
+            PackageOutput::Tarball => format!("{}.tar", name),
         }
     }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -10,15 +10,20 @@ use std::borrow::Cow;
 pub trait Progress {
     /// Updates the message displayed regarding progress constructing
     /// the package.
-    fn set_message(&self, msg: impl Into<Cow<'static, str>>);
+    fn set_message(&self, msg: Cow<'static, str>);
 
     /// Increments the number of things which have completed.
     fn increment(&self, delta: u64);
+
+    /// Returns a new [`Progress`] which will report progress for a sub task.
+    fn sub_progress(&self, _total: u64) -> Box<dyn Progress> {
+        Box::new(NoProgress)
+    }
 }
 
 /// Implements [`Progress`] as a no-op.
 pub struct NoProgress;
 impl Progress for NoProgress {
-    fn set_message(&self, _msg: impl Into<Cow<'static, str>>) {}
+    fn set_message(&self, _msg: Cow<'static, str>) {}
     fn increment(&self, _delta: u64) {}
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -12,6 +12,7 @@ mod test {
     use tar::Archive;
 
     use omicron_zone_package::blob::download;
+    use omicron_zone_package::progress::NoProgress;
 
     fn get_next<'a, R: 'a + Read>(entries: &mut tar::Entries<'a, R>) -> PathBuf {
         entries
@@ -212,8 +213,8 @@ mod test {
         let url = "OVMF_CODE.fd";
         let dst = out.path().join(url);
 
-        download(&url, &dst).await?;
-        download(&url, &dst).await?;
+        download(&NoProgress, &url, &dst).await?;
+        download(&NoProgress, &url, &dst).await?;
 
         Ok(())
     }


### PR DESCRIPTION
The current progress indication encompasses the whole package creation process but it'd be nice to be able to see progress of individual items within that. Specific use case here is for propolis where we also grab some blobs as part of that. It ends up looking something like this:


https://user-images.githubusercontent.com/287063/218639984-262725a4-f9ce-43ff-ad5a-e5b756be2bcb.mov

