### PR TITLE
Download blobs concurrently and sync to fs before trying to add to archive.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omicron-zone-package"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Sean Klein <sean@oxidecomputer.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -90,7 +90,17 @@ pub async fn download(progress: &impl Progress, source: &str, destination: &Path
     }
     drop(blob_progress);
 
-    // Flush file to disk
+    // tokio performs async file I/O via thread pools in the background
+    // and so just completing the `write_all` futures and dropping the
+    // file here is not necessarily enough to ensure the blob has been
+    // written out to the filesystem. This unfortunately can cause a race
+    // condition as `tar-rs` will read the file metadata to write out the
+    // tar Header and then subsequently read the file itself to write to
+    // the archive. This can cause us to create a corrupted archive if the
+    // file content size does not match the header size from the metadata.
+    // All this to say we need to explicitly sync here before returning
+    // and trying to add the blob to the archive.
+    file.sync_all().await?;
     drop(file);
 
     // Set destination file's modified time based on HTTPS response

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -25,8 +25,6 @@ pub async fn download(progress: &impl Progress, source: &str, destination: &Path
         .file_name()
         .ok_or_else(|| anyhow!("missing blob filename"))?;
 
-    progress.set_message(format!("adding blob: {}", blob.to_string_lossy()).into());
-
     let url = format!("{}/{}", S3_BUCKET, source);
     let client = reqwest::Client::new();
 
@@ -80,7 +78,7 @@ pub async fn download(progress: &impl Progress, source: &str, destination: &Path
 
     // Create a sub-progress for the blob download
     let blob_progress = progress.sub_progress(content_length);
-    blob_progress.set_message(format!("downloading {}", blob.to_string_lossy()).into());
+    blob_progress.set_message(blob.to_string_lossy().into_owned().into());
 
     let mut stream = response.bytes_stream();
     while let Some(chunk) = stream.next().await {


### PR DESCRIPTION
See the added block comment in `blob::download` but I believe this is the cause for why some of the propolis CI jobs have been failing on the packaging step (or at least one possibility).

Also updated the blob downloads to be done concurrently.