### PR TITLE
Add version stamps to zones, tarballs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ filetime = "0.2.20"
 flate2 = "1.0.25"
 futures-util = "0.3"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
+semver = { version = "1.0.16", features = ["std", "serde"] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 tar = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ description = "Packaging tools for Oxide's control plane software"
 anyhow = "1.0"
 async-trait = "0.1.64"
 chrono = "0.4.23"
-filetime = "0.2.20"
+filetime = "0.2"
 flate2 = "1.0.25"
 futures-util = "0.3"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }

--- a/src/package.rs
+++ b/src/package.rs
@@ -295,7 +295,9 @@ async fn new_zone_archive_builder(
     // See the OMICRON1(5) man page for more detail.
     let mut root_json = tokio::fs::File::from_std(tempfile::tempfile()?);
 
-    let version = version.map(|v| v.clone()).unwrap_or_else(|| DEFAULT_VERSION);
+    let version = version
+        .map(|v| v.clone())
+        .unwrap_or_else(|| DEFAULT_VERSION);
     let version = &version.to_string();
 
     let kvs = vec![
@@ -406,13 +408,14 @@ impl Package {
                 archive.mode(tar::HeaderMode::Deterministic);
                 archive.append_dir_all_async(".", tmp.path()).await?;
 
-                self.add_stamp_to_tarball_package(&mut archive, version).await?;
+                self.add_stamp_to_tarball_package(&mut archive, version)
+                    .await?;
 
                 // Finalize the archive.
                 archive.finish()?;
             }
         }
-        Ok(stamp_path.into())
+        Ok(stamp_path)
     }
 
     /// Returns the "total number of things to be done" when constructing a
@@ -754,7 +757,8 @@ impl Package {
                     .await?;
 
                 // Add a placeholder version stamp
-                self.add_stamp_to_tarball_package(&mut archive, &DEFAULT_VERSION).await?;
+                self.add_stamp_to_tarball_package(&mut archive, &DEFAULT_VERSION)
+                    .await?;
 
                 Ok(archive
                     .into_inner()

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -135,6 +135,7 @@ mod test {
         let mut archive = Archive::new(File::open(path).unwrap());
         let mut ents = archive.entries().unwrap();
         assert_eq!(Path::new("test-service"), get_next(&mut ents));
+        assert_eq!(Path::new("VERSION"), get_next(&mut ents));
         assert!(ents.next().is_none());
     }
 
@@ -164,6 +165,7 @@ mod test {
         let mut archive = Archive::new(File::open(path).unwrap());
         let mut ents = archive.entries().unwrap();
         assert_eq!(Path::new("test-service"), get_next(&mut ents));
+        assert_eq!(Path::new("VERSION"), get_next(&mut ents));
         assert!(ents.next().is_none());
     }
 


### PR DESCRIPTION
Part of https://github.com/oxidecomputer/omicron/issues/2447

Stamping creates the following package:

`out/omicron-nexus.tar.gz` -> `out/versioned/omicron-nexus.tar.gz`
`out/omicron-sled-agent.tar` -> `out/versioned/omicron-sled-agent.tar`

With an extra file, named either `root/opt/oxide/VERSION` (for zone images) or just `VERSION` (for the sled agent tarball).