### PR TITLE
Add support for path interpolation based on target

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   check-style:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     # actions/checkout@v2
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-18.04, macos-10.15 ]
+        os: [ ubuntu-20.04, macos-11 ]
     steps:
     # actions/checkout@v2
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ name = "omicron-zone-package"
 version = "0.7.1"
 authors = ["Sean Klein <sean@oxidecomputer.com>"]
 edition = "2018"
+#
+# Report a specific error in the case that the toolchain is too old for
+# let-else:
+#
+rust-version = "1.65.0"
 license = "MPL-2.0"
 repository = "https://github.com/oxidecomputer/omicron-package"
 description = "Packaging tools for Oxide's control plane software"

--- a/src/package.rs
+++ b/src/package.rs
@@ -338,6 +338,7 @@ impl Package {
 
     /// Identical to [`Self::create`], but allows a caller to receive updates
     /// about progress while constructing the package.
+    #[deprecated(note = "Call Self::create_with_progress_for_target instead")]
     pub async fn create_with_progress(
         &self,
         progress: &impl Progress,
@@ -346,6 +347,19 @@ impl Package {
     ) -> Result<File> {
         let null_target = Target(BTreeMap::new());
         self.create_internal(&null_target, progress, name, output_directory)
+            .await
+    }
+
+    /// Identical to [`Self::create`], but allows a caller to receive updates
+    /// about progress while constructing the package.
+    pub async fn create_with_progress_for_target(
+        &self,
+        progress: &impl Progress,
+        target: &Target,
+        name: &str,
+        output_directory: &Path,
+    ) -> Result<File> {
+        self.create_internal(&target, progress, name, output_directory)
             .await
     }
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 
 /// A target describes what platform and configuration we're trying
 /// to deploy on.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Target(pub BTreeMap<String, String>);
 
 impl Target {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -6,6 +6,7 @@
 mod test {
     use anyhow::Result;
     use omicron_zone_package::config;
+    use omicron_zone_package::target::Target;
     use std::fs::File;
     use std::io::Read;
     use std::path::{Path, PathBuf};
@@ -34,7 +35,10 @@ mod test {
 
         // Create the packaged file
         let out = tempfile::tempdir().unwrap();
-        package.create(package_name, out.path()).await.unwrap();
+        package
+            .create_for_target(&Target::default(), package_name, out.path())
+            .await
+            .unwrap();
 
         // Verify the contents
         let path = package.get_output_path(package_name, &out.path());
@@ -72,7 +76,10 @@ mod test {
 
         // Create the packaged file
         let out = tempfile::tempdir().unwrap();
-        package.create(package_name, out.path()).await.unwrap();
+        package
+            .create_for_target(&Target::default(), package_name, out.path())
+            .await
+            .unwrap();
 
         // Verify the contents
         let path = package.get_output_path(package_name, &out.path());
@@ -117,7 +124,10 @@ mod test {
 
         // Create the packaged file
         let out = tempfile::tempdir().unwrap();
-        package.create(package_name, out.path()).await.unwrap();
+        package
+            .create_for_target(&Target::default(), package_name, out.path())
+            .await
+            .unwrap();
 
         // Verify the contents
         let path = package.get_output_path(package_name, &out.path());
@@ -143,7 +153,10 @@ mod test {
 
         // Create the packaged file
         let out = tempfile::tempdir().unwrap();
-        package.create(package_name, out.path()).await.unwrap();
+        package
+            .create_for_target(&Target::default(), package_name, out.path())
+            .await
+            .unwrap();
 
         // Verify the contents
         let path = package.get_output_path(package_name, &out.path());
@@ -165,13 +178,19 @@ mod test {
         for package_name in package_dependencies {
             let package = cfg.packages.get(package_name).unwrap();
             // Create the packaged file
-            package.create(package_name, out.path()).await.unwrap();
+            package
+                .create_for_target(&Target::default(), package_name, out.path())
+                .await
+                .unwrap();
         }
 
         // Build the composite package
         let package_name = "pkg-3";
         let package = cfg.packages.get(package_name).unwrap();
-        package.create(package_name, out.path()).await.unwrap();
+        package
+            .create_for_target(&Target::default(), package_name, out.path())
+            .await
+            .unwrap();
 
         // Verify the contents
         let path = package.get_output_path(package_name, &out.path());


### PR DESCRIPTION
This feature is currently limited to the parsing of `MappedPaths`, but theoretically could be used elsewhere.

Allows for path interpolation based on the target. This will eventually allow us to use paths like:

```
from = "smf/service/{{key}}", to = "smf/"
```

And, when setting a `key = value` target, allow for switching between configuration files.