### PR TITLE
blob: validate status code on blob download

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -64,6 +64,9 @@ pub async fn download(progress: &impl Progress, source: &str, destination: &Path
     }
 
     let response = client.get(url).send().await?;
+    if !response.status().is_success() {
+        bail!("get failed! {:?}", response);
+    }
 
     // Store modified time from HTTPS response
     let last_modified = response


### PR DESCRIPTION
We checked that the initial HEAD request returned a valid status code (200-299) but didn't do it for the actual GET request.

This might be the cause of a failure I saw in [buildomat](https://buildomat.eng.oxide.computer/wg/0/details/01GX9ADQKWK3VWQ0AVKPYDK3HD/5KCnM0YpQNpY4wQtpzgDONeq91nRsd59xof8p5UzxR5ExfYL/01GX9AED4FYMSPXH2BP0GD6522):
```
Error: Digest mismatch downloading dendrite-asic: Saw 570a1b342070216185d243e323f2f4737537df4d4c135508c8f55beb83ef7a0d, expected 555d31972d7b622353ff61defe372a72e641b9677b10c4fb7e5ca84a1872a025
```
We "successfully" downloaded the blob but got a different digest? Grabbing it locally succeeds though:
```console
$ wget https://buildomat.eng.oxide.computer/public/file/oxidecomputer/dendrite/image/11e0730f6e300749fe1ca1028bb7ab30f62a9712/dendrite-asic.tar.gz
$ sha256sum dendrite-asic.tar.gz
555d31972d7b622353ff61defe372a72e641b9677b10c4fb7e5ca84a1872a025  dendrite-asic.tar.gz
```
It also succeeded on a retry so I'm assuming it was some intermittent network blip.

This addresses one aspect but it also might be worth adding some retry logic.

EDIT: ok, not the cause of the above buildomat issue because I forgot this only handles S3 download buckets. But probably good to fix anyways.