### PR TITLE
Add support for downloading prebuilt blobs from Buildomat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ chrono = "0.4.24"
 filetime = "0.2"
 flate2 = "1.0.25"
 futures-util = "0.3"
+hex = "0.4.3"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
+ring = "0.16.20"
 semver = { version = "1.0.17", features = ["std", "serde"] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"

--- a/src/package.rs
+++ b/src/package.rs
@@ -477,11 +477,7 @@ impl Package {
             } => {
                 let blob_work = blobs.as_ref().map(|b| b.len()).unwrap_or(0);
                 let buildomat_work = buildomat_blobs.as_ref().map(|b| b.len()).unwrap_or(0);
-                let blob_dir_work = if blob_work != 0 || buildomat_work != 0 {
-                    1
-                } else {
-                    0
-                };
+                let blob_dir_work = (blob_work != 0 || buildomat_work != 0) as usize;
                 let rust_work = rust.as_ref().map(|r| r.binary_names.len()).unwrap_or(0);
 
                 let mut paths_work = 0;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -231,11 +231,12 @@ mod test {
     async fn test_download() -> Result<()> {
         let out = tempfile::tempdir()?;
 
-        let url = "OVMF_CODE.fd";
-        let dst = out.path().join(url);
+        let path = PathBuf::from("OVMF_CODE.fd");
+        let src = omicron_zone_package::blob::Source::S3(&path);
+        let dst = out.path().join(&path);
 
-        download(&NoProgress, &url, &dst).await?;
-        download(&NoProgress, &url, &dst).await?;
+        download(&NoProgress, &src, &dst).await?;
+        download(&NoProgress, &src, &dst).await?;
 
         Ok(())
     }


### PR DESCRIPTION
Allow packaging TOMLs to define one or more `buildomat_blobs` that refer to a Buildomat artifact. This artifact need not be a zone image. Propolis's package manifest will use this to download firmware images built in CI (see https://github.com/oxidecomputer/propolis/issues/362).

The existing S3 blob type is not changed, and buildomat blobs are optional, so this should be a non-breaking change for existing package manifests.

Tested: cargo test; picked up the changes into Propolis's packaging utility and verified that they can be used to pick up guest firmware images produced by Buildomat.