### PR TITLE
Fix stamping tarball version if there is none yet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omicron-zone-package"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Sean Klein <sean@oxidecomputer.com>"]
 edition = "2018"
 #

--- a/src/package.rs
+++ b/src/package.rs
@@ -425,7 +425,11 @@ impl Package {
                 reader.unpack(tmp.path())?;
 
                 // Remove the placeholder version
-                std::fs::remove_file(tmp.path().join("VERSION"))?;
+                if let Err(err) = std::fs::remove_file(tmp.path().join("VERSION")) {
+                    if err.kind() != std::io::ErrorKind::NotFound {
+                        return Err(err.into());
+                    }
+                }
 
                 // Create the new tarball
                 let file = create_tarfile(&stamp_path)?;


### PR DESCRIPTION
Ran into this when trying to stamp a version into maghemite in the omicron CI scripts. The image we download doesn't contain a `VERSION`, so we hit the dreaded errno 2.

(If one of you would be willing to publish a 0.9.1 after this is merged, that would be appreciated, and I'll incorporate bumping to that version in what I'm working on for oxidecomputer/omicron#3430.)