### PR TITLE
Implement Package Caching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ description = "Packaging tools for Oxide's control plane software"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1.67"
-blake3 = { version = "1.5", features = ["rayon"] }
+blake3 = { version = "1.5", features = ["mmap", "rayon"] }
 chrono = "0.4.24"
 filetime = "0.2"
 flate2 = "1.0.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ flate2 = "1.0.25"
 futures = "0.3"
 futures-util = "0.3"
 hex = "0.4.3"
-once_cell = "1.19"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
 ring = "0.16.20"
 semver = { version = "1.0.17", features = ["std", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "omicron-zone-package"
 version = "0.10.1"
 authors = ["Sean Klein <sean@oxidecomputer.com>"]
-edition = "2018"
+edition = "2021"
 #
 # Report a specific error in the case that the toolchain is too old for
 # let-else:
@@ -24,6 +24,7 @@ flate2 = "1.0.25"
 futures = "0.3"
 futures-util = "0.3"
 hex = "0.4.3"
+once_cell = "1.19"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
 ring = "0.16.20"
 semver = { version = "1.0.17", features = ["std", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ description = "Packaging tools for Oxide's control plane software"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1.67"
+blake3 = { version = "1.5", features = ["rayon"] }
 chrono = "0.4.24"
 filetime = "0.2"
 flate2 = "1.0.25"
+futures = "0.3"
 futures-util = "0.3"
 hex = "0.4.3"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
@@ -26,6 +28,7 @@ semver = { version = "1.0.17", features = ["std", "serde"] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_json = "1.0"
+slog = "2.7"
 tar = "0.4"
 tempfile = "3.4"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ring = "0.16.20"
 semver = { version = "1.0.17", features = ["std", "serde"] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
+serde_json = "1.0"
 tar = "0.4"
 tempfile = "3.4"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ description = "Packaging tools for Oxide's control plane software"
 anyhow = "1.0"
 async-trait = "0.1.67"
 blake3 = { version = "1.5", features = ["mmap", "rayon"] }
+camino = { version = "1.1", features = ["serde1"] }
+camino-tempfile = "1.1"
 chrono = "0.4.24"
 filetime = "0.2"
 flate2 = "1.0.25"
@@ -30,7 +32,6 @@ serde_derive = "1.0"
 serde_json = "1.0"
 slog = "2.7"
 tar = "0.4"
-tempfile = "3.4"
 thiserror = "1.0"
 tokio = { version = "1.26", features = [ "full" ] }
 toml = "0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omicron-zone-package"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["Sean Klein <sean@oxidecomputer.com>"]
 edition = "2021"
 #

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,0 +1,150 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tools for creating and inserting into tarballs.
+
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use flate2::write::GzEncoder;
+use std::fs::{File, OpenOptions};
+use std::path::Path;
+use tar::Builder;
+
+#[async_trait]
+pub trait AsyncAppendFile {
+    async fn append_file_async<P>(&mut self, path: P, file: &mut File) -> std::io::Result<()>
+    where
+        P: AsRef<Path> + Send;
+
+    async fn append_path_with_name_async<P, N>(&mut self, path: P, name: N) -> std::io::Result<()>
+    where
+        P: AsRef<Path> + Send,
+        N: AsRef<Path> + Send;
+
+    async fn append_dir_all_async<P, Q>(&mut self, path: P, src_path: Q) -> std::io::Result<()>
+    where
+        P: AsRef<Path> + Send,
+        Q: AsRef<Path> + Send;
+}
+
+#[async_trait]
+impl<W: Encoder> AsyncAppendFile for Builder<W> {
+    async fn append_file_async<P>(&mut self, path: P, file: &mut File) -> std::io::Result<()>
+    where
+        P: AsRef<Path> + Send,
+    {
+        tokio::task::block_in_place(move || self.append_file(path, file))
+    }
+
+    async fn append_path_with_name_async<P, N>(&mut self, path: P, name: N) -> std::io::Result<()>
+    where
+        P: AsRef<Path> + Send,
+        N: AsRef<Path> + Send,
+    {
+        tokio::task::block_in_place(move || self.append_path_with_name(path, name))
+    }
+
+    async fn append_dir_all_async<P, Q>(&mut self, path: P, src_path: Q) -> std::io::Result<()>
+    where
+        P: AsRef<Path> + Send,
+        Q: AsRef<Path> + Send,
+    {
+        tokio::task::block_in_place(move || self.append_dir_all(path, src_path))
+    }
+}
+
+/// Helper to open a tarfile for reading/writing.
+pub fn create_tarfile<P: AsRef<Path> + std::fmt::Debug>(tarfile: P) -> Result<File> {
+    OpenOptions::new()
+        .write(true)
+        .read(true)
+        .truncate(true)
+        .create(true)
+        .open(tarfile.as_ref())
+        .map_err(|err| anyhow!("Cannot create tarfile {:?}: {}", tarfile, err))
+}
+
+/// Helper to open a tarfile for reading.
+pub fn open_tarfile<P: AsRef<Path> + std::fmt::Debug>(tarfile: P) -> Result<File> {
+    OpenOptions::new()
+        .read(true)
+        .open(tarfile.as_ref())
+        .map_err(|err| anyhow!("Cannot open tarfile {:?}: {}", tarfile, err))
+}
+
+pub trait Encoder: std::io::Write + Send {}
+impl<T> Encoder for T where T: std::io::Write + Send {}
+
+pub struct ArchiveBuilder<E: Encoder> {
+    pub builder: tar::Builder<E>,
+}
+
+impl<E: Encoder> ArchiveBuilder<E> {
+    pub fn new(builder: tar::Builder<E>) -> Self {
+        Self {
+            builder,
+        }
+    }
+
+    pub fn into_inner(self) -> Result<E> {
+        Ok(self.builder
+            .into_inner()
+            .with_context(|| "Finalizing archive")?)
+    }
+}
+
+/// Adds a package at `package_path` to a new zone image
+/// being built using the `archive` builder.
+pub async fn add_package_to_zone_archive<E: Encoder>(
+    archive: &mut ArchiveBuilder<E>,
+    package_path: &Path,
+) -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let gzr = flate2::read::GzDecoder::new(open_tarfile(package_path)?);
+    if gzr.header().is_none() {
+        return Err(anyhow!(
+            "Missing gzip header from {} - cannot add it to zone image",
+            package_path.display()
+        ));
+    }
+    let mut component_reader = tar::Archive::new(gzr);
+    let entries = component_reader.entries()?;
+
+    // First, unpack the existing entries
+    for entry in entries {
+        let mut entry = entry?;
+
+        // Ignore the JSON header files
+        let entry_path = entry.path()?;
+        if entry_path == Path::new("oxide.json") {
+            continue;
+        }
+
+        let entry_unpack_path = tmp.path().join(entry_path.strip_prefix("root/")?);
+        entry.unpack(&entry_unpack_path)?;
+        let entry_path = entry.path()?;
+        assert!(entry_unpack_path.exists());
+
+        archive
+            .builder
+            .append_path_with_name_async(entry_unpack_path, entry_path)
+            .await?;
+    }
+    Ok(())
+}
+
+pub async fn new_compressed_archive_builder(
+    path: &Path,
+) -> Result<ArchiveBuilder<GzEncoder<File>>> {
+    let file = create_tarfile(&path)?;
+    // TODO: Consider using async compression, async tar.
+    // It's not the *worst* thing in the world for a packaging tool to block
+    // here, but it would help the other async threads remain responsive if
+    // we avoided blocking.
+    let gzw = GzEncoder::new(file, flate2::Compression::fast());
+    let mut archive = Builder::new(gzw);
+    archive.mode(tar::HeaderMode::Deterministic);
+
+    Ok(ArchiveBuilder::new(archive))
+}

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -82,13 +82,12 @@ pub struct ArchiveBuilder<E: Encoder> {
 
 impl<E: Encoder> ArchiveBuilder<E> {
     pub fn new(builder: tar::Builder<E>) -> Self {
-        Self {
-            builder,
-        }
+        Self { builder }
     }
 
     pub fn into_inner(self) -> Result<E> {
-        Ok(self.builder
+        Ok(self
+            .builder
             .into_inner()
             .with_context(|| "Finalizing archive")?)
     }

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -4,7 +4,7 @@
 
 //! Tools for creating and inserting into tarballs.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use camino::Utf8Path;
 use flate2::write::GzEncoder;
@@ -106,10 +106,10 @@ pub async fn add_package_to_zone_archive<E: Encoder>(
     let tmp = camino_tempfile::tempdir()?;
     let gzr = flate2::read::GzDecoder::new(open_tarfile(package_path)?);
     if gzr.header().is_none() {
-        return Err(anyhow!(
+        bail!(
             "Missing gzip header from {} - cannot add it to zone image",
             package_path,
-        ));
+        );
     }
     let mut component_reader = tar::Archive::new(gzr);
     let entries = component_reader.entries()?;

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -12,6 +12,10 @@ use std::convert::TryInto;
 use std::fs::{File, OpenOptions};
 use tar::Builder;
 
+/// These interfaces are similar to some methods in [tar::Builder].
+///
+/// They use [tokio::block_in_place] to avoid blocking other async
+/// tasks using the executor.
 #[async_trait]
 pub trait AsyncAppendFile {
     async fn append_file_async<P>(&mut self, path: P, file: &mut File) -> std::io::Result<()>
@@ -89,9 +93,7 @@ impl<E: Encoder> ArchiveBuilder<E> {
     }
 
     pub fn into_inner(self) -> Result<E> {
-        self.builder
-            .into_inner()
-            .with_context(|| "Finalizing archive")
+        self.builder.into_inner().context("Finalizing archive")
     }
 }
 

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -21,12 +21,12 @@ const S3_BUCKET: &str = "https://oxide-omicron-build.s3.amazonaws.com";
 pub(crate) const BLOB: &str = "blob";
 
 #[derive(Debug)]
-pub enum Source<'a> {
-    S3(&'a PathBuf),
-    Buildomat(&'a crate::package::PrebuiltBlob),
+pub enum Source {
+    S3(PathBuf),
+    Buildomat(crate::package::PrebuiltBlob),
 }
 
-impl<'a> Source<'a> {
+impl Source {
     pub(crate) fn get_url(&self) -> String {
         match self {
             Self::S3(s) => format!("{}/{}", S3_BUCKET, s.to_string_lossy()),
@@ -90,11 +90,7 @@ impl<'a> Source<'a> {
 }
 
 // Downloads "source" from S3_BUCKET to "destination".
-pub async fn download<'a>(
-    progress: &impl Progress,
-    source: &Source<'a>,
-    destination: &Path,
-) -> Result<()> {
+pub async fn download(progress: &impl Progress, source: &Source, destination: &Path) -> Result<()> {
     let blob = destination
         .file_name()
         .ok_or_else(|| anyhow!("missing blob filename"))?;

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -21,7 +21,7 @@ const S3_BUCKET: &str = "https://oxide-omicron-build.s3.amazonaws.com";
 // Name for the directory component where downloaded blobs are stored.
 pub(crate) const BLOB: &str = "blob";
 
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Source {
     S3(PathBuf),
     Buildomat(crate::package::PrebuiltBlob),

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -92,7 +92,7 @@ impl Source {
 
 // Downloads "source" from S3_BUCKET to "destination".
 pub async fn download(
-    progress: &impl Progress,
+    progress: &dyn Progress,
     source: &Source,
     destination: &Utf8Path,
 ) -> Result<()> {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -115,8 +115,8 @@ impl<D: FileDigester> ArtifactManifest<D> {
         if extension != "json" {
             bail!("JSON encoding is all we know. Write to a '.json' file?");
         }
-        let serialized = serde_json::to_string(&self)
-            .with_context(|| "Failed to serialize ArtifactManifest to JSON")?;
+        let serialized =
+            serde_json::to_string(&self).context("Failed to serialize ArtifactManifest to JSON")?;
 
         let mut f = File::create(path).await?;
         f.write_all(serialized.as_bytes()).await?;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,129 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tracks inputs and outputs by digest to help caching
+
+use anyhow::{Context, Result, bail};
+use hex::ToHex;
+use ring::digest::{Context as DigestContext, Digest as ShaDigest, SHA256};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use tokio::fs::File;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+
+// The cache is stored in the output directory, with the following convention:
+//
+// out/cache/<artifact name>.json
+//
+// XXX do we need to differentiate by target?
+
+// Calculates the SHA256 digest for a file.
+async fn get_sha256_digest(path: &PathBuf) -> Result<ShaDigest> {
+    let mut reader = BufReader::new(
+        tokio::fs::File::open(&path)
+            .await
+            .with_context(|| format!("could not open {path:?}"))?,
+    );
+    let mut context = DigestContext::new(&SHA256);
+    let mut buffer = [0; 1024];
+
+    loop {
+        let count = reader
+            .read(&mut buffer)
+            .await
+            .with_context(|| format!("failed to read {path:?}"))?;
+        if count == 0 {
+            break;
+        } else {
+            context.update(&buffer[..count]);
+        }
+    }
+    Ok(context.finish())
+}
+
+#[derive(PartialEq, Eq, Serialize, Deserialize)]
+enum Digest {
+    // Sha256 support, as a hex-encoded string.
+    Sha2(String),
+
+    // I'd be interested in adding blake3 support someday, but I don't *love*
+    // the idea of diverging from our TUF repos, which are currently SHA2.
+    //
+    // blake3 would be faster though!
+}
+
+impl From<ShaDigest> for Digest {
+    fn from(digest: ShaDigest) -> Self {
+        Self::Sha2(digest.as_ref().encode_hex::<String>())
+    }
+}
+
+pub type Inputs = Vec<PathBuf>;
+pub type Outputs = Vec<PathBuf>;
+
+#[derive(PartialEq, Eq, Serialize, Deserialize)]
+struct ArtifactManifest {
+    // All inputs, which create this artifact
+    inputs: BTreeMap<PathBuf, Digest>,
+
+    // All outputs, created by this artifact
+    //
+    // For most artifacts, this is a single entry.
+    outputs: BTreeMap<PathBuf, Digest>,
+}
+
+impl ArtifactManifest {
+    /// Reads all inputs and outputs, collecting their digests.
+    pub async fn new_sha256(
+        input_paths: Inputs,
+        output_paths: Outputs,
+    ) -> Result<Self> {
+        let mut inputs = BTreeMap::new();
+        let mut outputs = BTreeMap::new();
+
+        for input_path in input_paths {
+            let digest = get_sha256_digest(&input_path).await?.into();
+            inputs.insert(input_path, digest);
+        }
+        for output_path in output_paths {
+            let digest = get_sha256_digest(&output_path).await?.into();
+            outputs.insert(output_path, digest);
+        }
+
+        Ok(Self {
+            inputs,
+            outputs,
+        })
+    }
+
+    /// Writes a manifest file to a particular location.
+    pub async fn write_to(&self, path: &PathBuf) -> Result<()> {
+        if !path.ends_with(".json") {
+            bail!("JSON encoding is all we know. Write to a '.json' file?");
+        }
+        let mut f = File::create(path).await?;
+        f.write_all(serde_json::to_string(&self)?.as_bytes()).await?;
+        Ok(())
+    }
+
+    /// Reads a manifest file to a particular location.
+    pub async fn read_from(path: &PathBuf) -> Result<Self> {
+        if !path.ends_with(".json") {
+            bail!("JSON encoding is all we know. Read from a '.json' file?");
+        }
+        let mut f = File::open(path).await?;
+        let mut buffer = String::new();
+        f.read_to_string(&mut buffer).await?;
+
+        Ok(serde_json::from_str(&buffer)?)
+    }
+}
+
+struct Cache {
+    output_directory: PathBuf,
+}
+
+impl Cache {
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -37,6 +37,8 @@ const HASH_BUFFER_SIZE: usize = 16 * (1 << 10);
 
 // When files are larger than this size, we try to hash them using techniques
 // like memory mapping and rayon.
+//
+// NOTE: This is currently only blake3-specific.
 const LARGE_HASH_SIZE: usize = 1 << 20;
 
 /// Implemented by algorithms which can take digests of files.

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Implements file digest support for caching
+
+use anyhow::Context;
+use async_trait::async_trait;
+use blake3::{Hash as BlakeDigest, Hasher as BlakeHasher};
+use camino::Utf8Path;
+use hex::ToHex;
+use ring::digest::{Context as DigestContext, Digest as ShaDigest, SHA256};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, BufReader};
+
+// The buffer size used to hash smaller files.
+const HASH_BUFFER_SIZE: usize = 16 * (1 << 10);
+
+// When files are larger than this size, we try to hash them using techniques
+// like memory mapping and rayon.
+//
+// NOTE: This is currently only blake3-specific.
+const LARGE_HASH_SIZE: usize = 1 << 20;
+
+/// Implemented by algorithms which can take digests of files.
+#[async_trait]
+pub trait FileDigester {
+    async fn get_digest(path: &Utf8Path) -> anyhow::Result<Digest>;
+}
+
+#[async_trait]
+impl FileDigester for ShaDigest {
+    async fn get_digest(path: &Utf8Path) -> anyhow::Result<Digest> {
+        let mut reader = BufReader::new(
+            tokio::fs::File::open(&path)
+                .await
+                .with_context(|| format!("could not open {path:?}"))?,
+        );
+        let mut context = DigestContext::new(&SHA256);
+        let mut buffer = [0; HASH_BUFFER_SIZE];
+        loop {
+            let count = reader
+                .read(&mut buffer)
+                .await
+                .with_context(|| format!("failed to read {path:?}"))?;
+            if count == 0 {
+                break;
+            } else {
+                context.update(&buffer[..count]);
+            }
+        }
+        let digest = context.finish().into();
+
+        Ok(digest)
+    }
+}
+
+#[async_trait]
+impl FileDigester for BlakeDigest {
+    async fn get_digest(path: &Utf8Path) -> anyhow::Result<Digest> {
+        let size = path.metadata()?.len();
+
+        let big_digest = size >= LARGE_HASH_SIZE as u64;
+        let mut hasher = BlakeHasher::new();
+
+        let digest = if big_digest {
+            let path = path.to_path_buf();
+            tokio::task::spawn_blocking(move || {
+                hasher.update_mmap_rayon(&path)?;
+                Ok::<Digest, anyhow::Error>(hasher.finalize().into())
+            })
+            .await??
+        } else {
+            let mut reader = BufReader::new(
+                tokio::fs::File::open(&path)
+                    .await
+                    .with_context(|| format!("could not open {path:?}"))?,
+            );
+            let mut buf = [0; HASH_BUFFER_SIZE];
+            loop {
+                let count = reader
+                    .read(&mut buf)
+                    .await
+                    .with_context(|| format!("failed to read {path:?}"))?;
+                if count == 0 {
+                    break;
+                }
+
+                let chunk = &buf[..count];
+                hasher.update(chunk);
+            }
+            hasher.finalize().into()
+        };
+
+        Ok(digest)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Digest {
+    // Sha256 support, as a hex-encoded string.
+    Sha2(String),
+    // Blake3 support, as a hex-encoded string.
+    Blake3(String),
+}
+
+impl From<ShaDigest> for Digest {
+    fn from(digest: ShaDigest) -> Self {
+        Self::Sha2(digest.as_ref().encode_hex::<String>())
+    }
+}
+
+impl From<BlakeDigest> for Digest {
+    fn from(digest: BlakeDigest) -> Self {
+        Self::Blake3(digest.as_bytes().encode_hex::<String>())
+    }
+}
+
+/// Although we support both interfaces, we use blake3 digests by default.
+pub type DefaultDigest = BlakeDigest;

--- a/src/input.rs
+++ b/src/input.rs
@@ -4,18 +4,17 @@
 
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use std::collections::BTreeSet;
 
 /// A directory that should be added to the target archive
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TargetDirectory(pub PathBuf);
 
 /// A package that should be added to the target archive
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TargetPackage(pub PathBuf);
 
 /// A pair of paths, mapping from a file or directory on the host to the target
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MappedPath {
     /// Source path.
     pub from: PathBuf,
@@ -24,15 +23,12 @@ pub struct MappedPath {
 }
 
 /// All possible inputs which are used to construct Omicron packages
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum BuildInput {
     /// Adds a single file, which is stored in-memory.
     ///
     /// This is mostly used as a way to cache metadata.
-    AddInMemoryFile {
-        dst_path: PathBuf,
-        contents: String,
-    },
+    AddInMemoryFile { dst_path: PathBuf, contents: String },
 
     /// Add a single directory to the target archive.
     ///
@@ -74,14 +70,11 @@ impl BuildInput {
     }
 }
 
-/// A orderd, unique collection of build inputs.
-///
-/// When referring to multiple inputs, it's important to preserve the properties
-/// of uniqueness and order for build determinism.
-pub struct BuildInputs(pub BTreeSet<BuildInput>);
+/// A ordered collection of build inputs.
+pub struct BuildInputs(pub Vec<BuildInput>);
 
 impl BuildInputs {
     pub fn new() -> Self {
-        Self(BTreeSet::new())
+        Self(vec![])
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,87 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::collections::BTreeSet;
+
+/// A directory that should be added to the target archive
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct TargetDirectory(pub PathBuf);
+
+/// A package that should be added to the target archive
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct TargetPackage(pub PathBuf);
+
+/// A pair of paths, mapping from a file or directory on the host to the target
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct MappedPath {
+    /// Source path.
+    pub from: PathBuf,
+    /// Destination path.
+    pub to: PathBuf,
+}
+
+/// All possible inputs which are used to construct Omicron packages
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+pub enum BuildInput {
+    /// Adds a single file, which is stored in-memory.
+    ///
+    /// This is mostly used as a way to cache metadata.
+    AddInMemoryFile {
+        dst_path: PathBuf,
+        contents: String,
+    },
+
+    /// Add a single directory to the target archive.
+    ///
+    /// This directory doesn't need to exist on the build host.
+    AddDirectory(TargetDirectory),
+
+    /// Add a file directly from source to target.
+    AddFile(MappedPath),
+
+    /// Add a dowloaded file from source to target.
+    ///
+    /// This is similar to "AddFile", though it may require downloading an input
+    /// first.
+    AddBlob {
+        path: MappedPath,
+        blob: crate::blob::Source,
+    },
+
+    /// Add a package from source to target.
+    ///
+    /// This is similar to "AddFile", though it requires unpacking the package
+    /// and re-packaging it into the target.
+    AddPackage(TargetPackage),
+}
+
+impl BuildInput {
+    /// If the input has a path on the host machine, return it.
+    pub fn input_path(&self) -> Option<&Path> {
+        match self {
+            // This file is stored in-memory, it isn't cached.
+            BuildInput::AddInMemoryFile { .. } => None,
+            // This path doesn't need to exist on the host, it's just fabricated
+            // on the target.
+            BuildInput::AddDirectory(_target) => None,
+            BuildInput::AddFile(mapped_path) => Some(&mapped_path.from),
+            BuildInput::AddBlob { path, .. } => Some(&path.from),
+            BuildInput::AddPackage(target_package) => Some(&target_package.0),
+        }
+    }
+}
+
+/// A orderd, unique collection of build inputs.
+///
+/// When referring to multiple inputs, it's important to preserve the properties
+/// of uniqueness and order for build determinism.
+pub struct BuildInputs(pub BTreeSet<BuildInput>);
+
+impl BuildInputs {
+    pub fn new() -> Self {
+        Self(BTreeSet::new())
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -2,24 +2,24 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use camino::{Utf8Path, Utf8PathBuf};
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
 
 /// A directory that should be added to the target archive
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct TargetDirectory(pub PathBuf);
+pub struct TargetDirectory(pub Utf8PathBuf);
 
 /// A package that should be added to the target archive
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct TargetPackage(pub PathBuf);
+pub struct TargetPackage(pub Utf8PathBuf);
 
 /// A pair of paths, mapping from a file or directory on the host to the target
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MappedPath {
     /// Source path.
-    pub from: PathBuf,
+    pub from: Utf8PathBuf,
     /// Destination path.
-    pub to: PathBuf,
+    pub to: Utf8PathBuf,
 }
 
 /// All possible inputs which are used to construct Omicron packages
@@ -28,7 +28,10 @@ pub enum BuildInput {
     /// Adds a single file, which is stored in-memory.
     ///
     /// This is mostly used as a way to cache metadata.
-    AddInMemoryFile { dst_path: PathBuf, contents: String },
+    AddInMemoryFile {
+        dst_path: Utf8PathBuf,
+        contents: String,
+    },
 
     /// Add a single directory to the target archive.
     ///
@@ -56,7 +59,7 @@ pub enum BuildInput {
 
 impl BuildInput {
     /// If the input has a path on the host machine, return it.
-    pub fn input_path(&self) -> Option<&Path> {
+    pub fn input_path(&self) -> Option<&Utf8Path> {
         match self {
             // This file is stored in-memory, it isn't cached.
             BuildInput::AddInMemoryFile { .. } => None,
@@ -76,5 +79,11 @@ pub struct BuildInputs(pub Vec<BuildInput>);
 impl BuildInputs {
     pub fn new() -> Self {
         Self(vec![])
+    }
+}
+
+impl Default for BuildInputs {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 pub mod blob;
+pub mod cache;
 pub mod config;
 pub mod package;
 pub mod progress;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+mod archive;
 pub mod blob;
 pub mod cache;
 pub mod config;
+pub mod input;
 pub mod package;
 pub mod progress;
 pub mod target;
+mod timer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod archive;
 pub mod blob;
 pub mod cache;
 pub mod config;
+mod digest;
 pub mod input;
 pub mod package;
 pub mod progress;

--- a/src/package.rs
+++ b/src/package.rs
@@ -52,7 +52,7 @@ fn zone_get_all_parent_inputs(to: &Utf8Path) -> Result<Vec<TargetDirectory>> {
     parents.reverse();
 
     if to.is_relative() {
-        return Err(anyhow!("Cannot add 'to = {to}'; absolute path required",));
+        bail!("Cannot add 'to = {to}'; absolute path required");
     }
 
     let mut outputs = vec![];
@@ -452,11 +452,11 @@ impl Package {
             if !from.exists() {
                 // Strictly speaking, this check is redundant, but it provides
                 // a better error message.
-                return Err(anyhow!(
+                bail!(
                     "Cannot add path \"{}\" to package \"{}\" because it does not exist",
                     from,
                     self.service_name,
-                ));
+                );
             }
 
             let from_root = std::fs::canonicalize(&from)
@@ -543,10 +543,10 @@ impl Package {
                 }
             }
             _ => {
-                return Err(anyhow!(
+                bail!(
                     "Cannot walk over a zone package with source: {:?}",
                     self.source
-                ));
+                );
             }
         }
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -750,7 +750,6 @@ impl Package {
             .with_context(|| "Identifying all input paths")?;
         progress.increment_total(inputs.0.len() as u64);
 
-        let log = progress.get_log();
         match cache.lookup(&output_file, &inputs).await {
             Ok(_) => {
                 progress.set_message("Cache hit".into());
@@ -773,10 +772,6 @@ impl Package {
             self.add_input_to_package(progress, &mut archive, &input)
                 .await?;
         }
-
-        // Add a placeholder version stamp
-        self.add_stamp_to_tarball_package(&mut archive.builder, &DEFAULT_VERSION)
-            .await?;
 
         let file = archive
             .builder

--- a/src/package.rs
+++ b/src/package.rs
@@ -637,7 +637,7 @@ impl Package {
         let zoned = true;
         let inputs = self
             .get_all_inputs(name, target, output_directory, zoned, None)
-            .with_context(|| "Identifying all input paths")?;
+            .context("Identifying all input paths")?;
         progress.increment_total(inputs.0.len() as u64);
 
         let output_file = self.get_output_file(name);
@@ -657,7 +657,7 @@ impl Package {
                 progress.set_message("Cache miss".into());
             }
             Err(CacheError::Other(other)) => {
-                return Err(other).with_context(|| "Reading from package cache");
+                return Err(other).context("Reading from package cache");
             }
         }
 
@@ -680,7 +680,7 @@ impl Package {
         cache
             .update(&inputs, &output_path)
             .await
-            .with_context(|| "Updating package cache")?;
+            .context("Updating package cache")?;
 
         timer.finish()?;
         Ok(file)
@@ -779,7 +779,7 @@ impl Package {
         let zoned = false;
         let inputs = self
             .get_all_inputs(name, config.target, output_directory, zoned, None)
-            .with_context(|| "Identifying all input paths")?;
+            .context("Identifying all input paths")?;
         progress.increment_total(inputs.0.len() as u64);
 
         match cache.lookup(&inputs, &output_path).await {
@@ -791,7 +791,7 @@ impl Package {
                 progress.set_message("Cache miss".into());
             }
             Err(CacheError::Other(other)) => {
-                return Err(other).with_context(|| "Reading from package cache");
+                return Err(other).context("Reading from package cache");
             }
         }
 
@@ -814,7 +814,7 @@ impl Package {
         cache
             .update(&inputs, &output_path)
             .await
-            .with_context(|| "Updating package cache")?;
+            .context("Updating package cache")?;
 
         Ok(file)
     }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -4,7 +4,7 @@
 
 //! Describes utilities for relaying progress to end-users.
 
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
 use slog::Logger;
 use std::borrow::Cow;
 
@@ -31,13 +31,13 @@ pub trait Progress {
 
 /// Implements [`Progress`] as a no-op.
 pub struct NoProgress {
-    log: OnceCell<slog::Logger>,
+    log: OnceLock<slog::Logger>,
 }
 
 impl NoProgress {
     pub const fn new() -> Self {
         Self {
-            log: OnceCell::new(),
+            log: OnceLock::new(),
         }
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -41,6 +41,12 @@ impl NoProgress {
     }
 }
 
+impl Default for NoProgress {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Progress for NoProgress {
     fn get_log(&self) -> &Logger {
         &self.log

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -4,9 +4,9 @@
 
 //! Describes utilities for relaying progress to end-users.
 
-use std::sync::OnceLock;
 use slog::Logger;
 use std::borrow::Cow;
+use std::sync::OnceLock;
 
 /// Trait for propagating progress information while constructing the package.
 pub trait Progress {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -4,26 +4,43 @@
 
 //! Describes utilities for relaying progress to end-users.
 
+use slog::Logger;
 use std::borrow::Cow;
 
 /// Trait for propagating progress information while constructing the package.
 pub trait Progress {
     /// Updates the message displayed regarding progress constructing
     /// the package.
-    fn set_message(&self, msg: Cow<'static, str>);
+    fn set_message(&self, _msg: Cow<'static, str>) {}
+
+    /// Returns the debug logger
+    fn get_log(&self) -> &Logger;
+
+    /// Increments the number of things which need to be completed
+    fn increment_total(&self, _delta: u64) {}
 
     /// Increments the number of things which have completed.
-    fn increment(&self, delta: u64);
+    fn increment_completed(&self, _delta: u64) {}
 
     /// Returns a new [`Progress`] which will report progress for a sub task.
     fn sub_progress(&self, _total: u64) -> Box<dyn Progress> {
-        Box::new(NoProgress)
+        Box::new(NoProgress::new())
     }
 }
 
 /// Implements [`Progress`] as a no-op.
-pub struct NoProgress;
+pub struct NoProgress {
+    log: slog::Logger,
+}
+
+impl NoProgress {
+    pub fn new() -> Self {
+        Self {
+            log: slog::Logger::root(slog::Discard, slog::o!())
+        }
+    }
+}
+
 impl Progress for NoProgress {
-    fn set_message(&self, _msg: Cow<'static, str>) {}
-    fn increment(&self, _delta: u64) {}
+    fn get_log(&self) -> &Logger { &self.log }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -4,6 +4,7 @@
 
 //! Describes utilities for relaying progress to end-users.
 
+use once_cell::sync::OnceCell;
 use slog::Logger;
 use std::borrow::Cow;
 
@@ -30,13 +31,13 @@ pub trait Progress {
 
 /// Implements [`Progress`] as a no-op.
 pub struct NoProgress {
-    log: slog::Logger,
+    log: OnceCell<slog::Logger>,
 }
 
 impl NoProgress {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
-            log: slog::Logger::root(slog::Discard, slog::o!()),
+            log: OnceCell::new(),
         }
     }
 }
@@ -49,6 +50,7 @@ impl Default for NoProgress {
 
 impl Progress for NoProgress {
     fn get_log(&self) -> &Logger {
-        &self.log
+        self.log
+            .get_or_init(|| slog::Logger::root(slog::Discard, slog::o!()))
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -36,11 +36,13 @@ pub struct NoProgress {
 impl NoProgress {
     pub fn new() -> Self {
         Self {
-            log: slog::Logger::root(slog::Discard, slog::o!())
+            log: slog::Logger::root(slog::Discard, slog::o!()),
         }
     }
 }
 
 impl Progress for NoProgress {
-    fn get_log(&self) -> &Logger { &self.log }
+    fn get_log(&self) -> &Logger {
+        &self.log
+    }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,0 +1,116 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A timer to help track how long build phases take
+
+use anyhow::{bail, Result};
+use slog::Logger;
+use std::borrow::Cow;
+use tokio::time::{Duration, Instant};
+
+type CowStr = Cow<'static, str>;
+
+struct PhaseStart {
+    name: CowStr,
+    time: Instant,
+}
+
+struct PhaseEnd {
+    name: Option<CowStr>,
+    time: Instant,
+}
+
+impl PhaseStart {
+    fn new(name: CowStr) -> Self {
+        Self {
+            name,
+            time: Instant::now(),
+        }
+    }
+
+    fn finish(self, name: Option<CowStr>) -> Phase {
+        Phase {
+            start: self,
+            end: PhaseEnd {
+                name,
+                time: Instant::now(),
+            },
+        }
+    }
+}
+
+pub struct Phase {
+    start: PhaseStart,
+    end: PhaseEnd,
+}
+
+impl Phase {
+    pub fn name(&self) -> &str {
+        &self.start.name
+    }
+
+    pub fn end_label(&self) -> Option<&str> {
+        self.end.name.as_deref()
+    }
+
+    pub fn duration(&self) -> Duration {
+        self.end.time.duration_since(self.start.time)
+    }
+}
+
+pub struct BuildTimer {
+    current: Option<PhaseStart>,
+    past: Vec<Phase>,
+}
+
+impl BuildTimer {
+    pub fn new() -> Self {
+        Self {
+            current: None,
+            past: vec![],
+        }
+    }
+
+    pub fn start<S: Into<CowStr>>(&mut self, s: S) {
+        // If a prior phase was ongoing, mark it completed
+        if self.current.is_some() {
+            let _ = self.finish();
+        }
+        self.current = Some(PhaseStart::new(s.into()));
+    }
+
+    pub fn finish_with_label<S: Into<CowStr>>(&mut self, label: S) -> Result<()> {
+        self.finish_inner(Some(label.into()))
+    }
+
+    pub fn finish(&mut self) -> Result<()> {
+        self.finish_inner(Option::<CowStr>::None)
+    }
+
+    fn finish_inner(&mut self, label: Option<CowStr>) -> Result<()> {
+        let Some(current) = self.current.take() else {
+            bail!("No build phase in progress");
+        };
+        self.past.push(current.finish(label));
+        Ok(())
+    }
+
+    pub fn completed(&self) -> &Vec<Phase> {
+        &self.past
+    }
+
+    pub fn log_all(&self, log: &Logger) {
+        for phase in self.completed() {
+            let name = phase.name();
+            let s = phase.duration().as_secs();
+            let ms = phase.duration().subsec_micros();
+            let label = if let Some(label) = phase.end_label() {
+                format!(" -- {label}")
+            } else {
+                "".to_string()
+            };
+            slog::info!(log, "Phase {name} took {s}.{ms}s{label}");
+        }
+    }
+}

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -103,14 +103,13 @@ impl BuildTimer {
     pub fn log_all(&self, log: &Logger) {
         for phase in self.completed() {
             let name = phase.name();
-            let s = phase.duration().as_secs();
-            let ms = phase.duration().subsec_micros();
+            let s = phase.duration().as_secs_f64();
             let label = if let Some(label) = phase.end_label() {
                 format!(" -- {label}")
             } else {
                 "".to_string()
             };
-            slog::info!(log, "Phase {name} took {s}.{ms}s{label}");
+            slog::info!(log, "Phase {name} took {s:.6}s{label}");
         }
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -40,6 +40,7 @@ impl PhaseStart {
     }
 }
 
+/// Describes a single phase of time, with a start time, end time, and label.
 pub struct Phase {
     start: PhaseStart,
     end: PhaseEnd,
@@ -59,6 +60,7 @@ impl Phase {
     }
 }
 
+/// A utility for tracking a series of related timers.
 pub struct BuildTimer {
     current: Option<PhaseStart>,
     past: Vec<Phase>,
@@ -72,6 +74,7 @@ impl BuildTimer {
         }
     }
 
+    /// Starts a new timer, ending a prior phase if one was in progress.
     pub fn start<S: Into<CowStr>>(&mut self, s: S) {
         // If a prior phase was ongoing, mark it completed
         if self.current.is_some() {
@@ -80,10 +83,12 @@ impl BuildTimer {
         self.current = Some(PhaseStart::new(s.into()));
     }
 
+    /// Terminates the current phase with a label.
     pub fn finish_with_label<S: Into<CowStr>>(&mut self, label: S) -> Result<()> {
         self.finish_inner(Some(label.into()))
     }
 
+    /// Terminates the current phase.
     pub fn finish(&mut self) -> Result<()> {
         self.finish_inner(Option::<CowStr>::None)
     }
@@ -96,10 +101,12 @@ impl BuildTimer {
         Ok(())
     }
 
+    /// Returns all previously completed phases.
     pub fn completed(&self) -> &Vec<Phase> {
         &self.past
     }
 
+    /// A helper for logging all [Self::completed] phases.
     pub fn log_all(&self, log: &Logger) {
         for phase in self.completed() {
             let name = phase.name();

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -6,15 +6,16 @@
 mod test {
     use anyhow::Result;
     use camino::Utf8PathBuf;
-    use omicron_zone_package::config;
-    use omicron_zone_package::target::Target;
     use std::convert::TryInto;
     use std::fs::File;
     use std::io::Read;
     use tar::Archive;
 
     use omicron_zone_package::blob::download;
+    use omicron_zone_package::config;
+    use omicron_zone_package::package::BuildConfig;
     use omicron_zone_package::progress::NoProgress;
+    use omicron_zone_package::target::Target;
 
     fn entry_path<'a, R>(entry: &tar::Entry<'a, R>) -> Utf8PathBuf
     where
@@ -62,8 +63,9 @@ mod test {
 
         // Create the packaged file
         let out = camino_tempfile::tempdir().unwrap();
+        let build_config = BuildConfig::default();
         package
-            .create_for_target(&Target::default(), package_name, out.path())
+            .create(package_name, out.path(), &build_config)
             .await
             .unwrap();
 
@@ -100,8 +102,9 @@ mod test {
 
         // Create the packaged file
         let out = camino_tempfile::tempdir().unwrap();
+        let build_config = BuildConfig::default();
         package
-            .create_for_target(&Target::default(), package_name, out.path())
+            .create(package_name, out.path(), &build_config)
             .await
             .unwrap();
 
@@ -142,8 +145,9 @@ mod test {
 
         // Create the packaged file
         let out = camino_tempfile::tempdir().unwrap();
+        let build_config = BuildConfig::default();
         package
-            .create_for_target(&Target::default(), package_name, out.path())
+            .create(package_name, out.path(), &build_config)
             .await
             .unwrap();
 
@@ -196,8 +200,9 @@ mod test {
 
         // Create the packaged file
         let out = camino_tempfile::tempdir().unwrap();
+        let build_config = BuildConfig::default();
         package
-            .create_for_target(&Target::default(), package_name, out.path())
+            .create(package_name, out.path(), &build_config)
             .await
             .unwrap();
 
@@ -226,10 +231,11 @@ mod test {
         let mut batch_pkg_names: Vec<_> = batch.iter().map(|(name, _)| *name).collect();
         batch_pkg_names.sort();
         assert_eq!(batch_pkg_names, vec!["pkg-1", "pkg-2"]);
+        let build_config = BuildConfig::default();
         for (package_name, package) in batch {
             // Create the packaged file
             package
-                .create_for_target(&Target::default(), package_name, out.path())
+                .create(package_name, out.path(), &build_config)
                 .await
                 .unwrap();
         }
@@ -240,8 +246,9 @@ mod test {
         let package_name = "pkg-3";
         assert_eq!(batch_pkg_names, vec![package_name]);
         let package = cfg.packages.get(package_name).unwrap();
+        let build_config = BuildConfig::default();
         package
-            .create_for_target(&Target::default(), package_name, out.path())
+            .create(package_name, out.path(), &build_config)
             .await
             .unwrap();
 


### PR DESCRIPTION
This PR is a bit of an overhaul of omicron-package, doing the following:

## Overview

- It splits out "collection of inputs" from "actually shoving inputs into the package". This separation is necessary to allow us to inspect inputs before deciding whether or not to rebuild packages.
- It refactors different subcomponents of package building into new modules: `archive.rs` for building archives, `digest.rs` for collecting file digests, `input.rs` for collecting inputs.
- It adds a "build timer" in `timer.rs` for ease-of-use, measuring build phases.
- It plumbs a logger through the `Progress` trait so we can get better debug information without fighting the TUI-based interface. In Omicron, this will default to `out/LOG`.
- It switches from using `std::path::Path` to `camino`.

## So How Does Caching Work

- We currently emit artifacts to an output directory -- by default, from Omicron, this is named `out/`.
- In this PR, we add a subdirectory named `out/manifest-cache`, which stores a JSON file for each output we expect to build. This JSON file contains the set of all inputs used to construct the output, with their digests. Although this PR adds support for both SHA-2 and Blake-3, we use Blake-3 by default.
- BEFORE we build a package, we look up the expected output in this cache. If all inputs are the same and the output exists, we use the output.
- AFTER we build a package, we update the JSON manifest file.

## TO-DO list before merging

- [x] Add configuration option to "skip caching altogether", to triple-check we aren't introducing any performance regressions
- [x] We could make the "cache miss" case faster by comparing file lengths before digests
- [x] Add more tests