### PR TITLE
replace ring with sha2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,11 @@ futures = "0.3"
 futures-util = "0.3"
 hex = "0.4.3"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
-ring = "0.16.20"
 semver = { version = "1.0.17", features = ["std", "serde"] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_json = "1.0"
+sha2 = "0.10.8"
 slog = "2.7"
 tar = "0.4"
 thiserror = "1.0"


### PR DESCRIPTION
This use of `ring@0.16` is the only such use in Omicron's dep tree, and it's only used for its SHA-2 implementation.