### PR TITLE
Add downloaded blobs to package tarball

### DIFF
--- a/src/package.rs
+++ b/src/package.rs
@@ -769,6 +769,15 @@ impl Package {
                 blob::download(progress, blob, &blob_path)
                     .await
                     .with_context(|| format!("failed to download blob: {}", blob.get_url()))?;
+
+                let src = &blob_path;
+                let dst = &path.to;
+                progress.set_message(format!("adding file: {}", src).into());
+                archive
+                    .builder
+                    .append_path_with_name_async(src, dst)
+                    .await
+                    .context(format!("Failed to add file '{}' to '{}'", src, dst,))?;
             }
             BuildInput::AddPackage(component_package) => {
                 progress.set_message(format!("adding package: {}", component_package.0).into());


### PR DESCRIPTION
While updating propolis to from its quite old (0.9) version of omicron-zone-package, I noticed that the S3 blobs included in its manifest were being downloaded but not appended to the archive.  It appears that such functionality was disrupted as part of the overhaul in #60.

This should restore blob inclusion in the package.