### PR TITLE
Release v0.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omicron-zone-package"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Sean Klein <sean@oxidecomputer.com>"]
 edition = "2021"
 rust-version = "1.81.0"


### PR DESCRIPTION
With the #75 fix in place, it would be nice to publish a patch release so propolis can pick it up via crates.io.