### PR TITLE
ensure blob directory exists in archives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omicron-zone-package"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Sean Klein <sean@oxidecomputer.com>"]
 edition = "2021"
 rust-version = "1.81.0"

--- a/src/package.rs
+++ b/src/package.rs
@@ -603,6 +603,14 @@ impl Package {
     fn get_blobs_inputs(&self, download_directory: &Utf8Path, zoned: bool) -> Result<BuildInputs> {
         let mut inputs = BuildInputs::new();
 
+        // If there are no blobs in the source description, there's no work to
+        // do. It's important to short-circuit here to avoid adding an empty
+        // blob directory entry to zone archives that won't actually contain
+        // any blobs.
+        if self.source.blobs().is_none() && self.source.buildomat_blobs().is_none() {
+            return Ok(inputs);
+        }
+
         let destination_path = if zoned {
             let dst = Utf8Path::new("/opt/oxide")
                 .join(self.service_name.as_str())


### PR DESCRIPTION
The helios-omicron-brand code that unpacks zone images requires all file entries in an archive to be preceded by entries that create those files' directories. Ensure the packaging code adds the requisite entries for downloaded blobs (as it already does for Rust programs).

Propolis will need a patch release containing this fix to produce functioning Omicron zone images, so I've bumped the package version to 0.12.2 in this commit; let me know if I should do that in a separate PR.

Tested by building a Propolis package using this commit and verifying that (a) `tar -tzf` prints the appropriate output structure, and (b) hotpatching an Omicron dev cluster with this zone image allows instances to start (images created without the fix produce a file-not-found error when sled-agent tries to start them).